### PR TITLE
Update index.html - Путанница в названии клавиатуры

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
 
                 <h3 class="section-title">БК-0010</h3>
 
-                <p style="text-align:center;font-style:italic;margin:10px 0;">1985 год. Базовая модель с пленочной
+                <p style="text-align:center;font-style:italic;margin:10px 0;">1985 год. Базовая модель с "плоской"
                     клавиатурой и интерпретатором языка Фокал в ПЗУ</p>
 
                 <div class="featured-item">


### PR DESCRIPTION
Клавиатура ранних БК - не является пленочной. Плёночными клавиатурами оснащены, как раз, самые поздние модели БК0010-01 и БК0011М. А данную клавиатуру, во избежание путанницы, принято называть "плоской".